### PR TITLE
Support MPFR 4.2.0

### DIFF
--- a/src/libm-tester/testerutil.c
+++ b/src/libm-tester/testerutil.c
@@ -289,6 +289,7 @@ double countULP2sp(float d, mpfr_t c0) {
 
 //
 
+#if MPFR_VERSION < MPFR_VERSION_NUM(4,2,0)
 void mpfr_sinpi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
   mpfr_t frpi, frd;
   mpfr_inits(frpi, frd, NULL);
@@ -314,6 +315,7 @@ void mpfr_cospi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
 
   mpfr_clears(frpi, frd, NULL);
 }
+#endif // MPFR_VERSION < MPFR_VERSION_NUM(4,2,0)
 
 void mpfr_lgamma_nosign(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
   int s;

--- a/src/libm-tester/testerutil.h
+++ b/src/libm-tester/testerutil.h
@@ -90,7 +90,9 @@ int cmpDenormsp(float x, mpfr_t fry);
 double countULPsp(float d, mpfr_t c);
 double countULP2sp(float d, mpfr_t c);
 
+#if MPFR_VERSION < MPFR_VERSION_NUM(4,2,0)
 void mpfr_sinpi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
 void mpfr_cospi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
+#endif
 void mpfr_lgamma_nosign(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
 #endif


### PR DESCRIPTION
MPFR 4.2.0 introduces mpfr_sinpi and mpfr_cospi, which conflict with SLEEF's implementations.